### PR TITLE
Run updateFunctionCode when there is actually a match

### DIFF
--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -105,8 +105,8 @@ function deployFunction(region, fnName, zipfile, script, executionRole, descript
       return fn.FunctionName === fnName;
     });
 
-    if (match) createFunction();
-    else updateFunctionCode();
+    if (match.length) updateFunctionCode();
+    else createFunction();
   });
 
   function createFunction() {


### PR DESCRIPTION
`createFunction` was being called every time `deployFunction` was called since `if (match)...` was always true being an empty array. Also, if there was a match, it should update, not create.

cc @rclark 