### PR TITLE
Bundle all streambot's dependencies

### DIFF
--- a/bin/bundle
+++ b/bin/bundle
@@ -20,8 +20,8 @@ npm install --production \
   --target_platform=linux \
   --target_arch=x64 > /dev/null 2>&1
 
-# Install streambot runtime dependencies
-npm install --production aws-sdk dotenv fastlog > /dev/null 2>&1
+# Install all streambot's dependencies
+npm install --production aws-sdk dotenv fastlog minimist queue-async underscore > /dev/null 2>&1
 
 mkdir -p "$1/build"
 zipfile="$1/build/bundle.zip"


### PR DESCRIPTION
Lambda seems to have changed the way that it reads dependencies. Previously streambot only bundled its own _runtime dependencies_ and did not install those dependencies that it uses for bundle/deploy scripts.

Today I did a deploy that started failing because it couldn't find some of these _deploy-time dependencies_. Installing them in the bundle is trivial and solved the issue.

cc @camilleanne 