### PR TITLE
Never allow null Reason on CFN responses

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,6 +70,11 @@ function respond(err, data, event, context) {
   if (err) console.log(err);
   var status = err ? 'FAILED' : 'SUCCESS';
 
+  if (err && !err.message) {
+    err.message = 'An unexpected error occurred';
+    if (err.code) err.message += ': ' + err.code;
+  }
+
   var body = JSON.stringify({
     Status: status,
     Reason: err ? err.message : '',


### PR DESCRIPTION
If the CFN response from a Lambda function is `status: 'FAILED'` and `Reason: null`, CFN will just hang indefinitely. aws-sdk `InternalError`s come back with a `null` message, so this handles the case by making sure that there is always a `Reason`

cc @emilymcafee 