### PR TITLE
Reuse table and multi-region lambda functions

### DIFF
--- a/.slugger.json
+++ b/.slugger.json
@@ -1,3 +1,4 @@
 {
-  "slug-zip": true
+  "slug-zip": true,
+  "slug-acl": "public-read"
 }

--- a/.slugger.json
+++ b/.slugger.json
@@ -1,4 +1,3 @@
 {
-  "slug-zip": true,
-  "slug-acl": "public-read"
+  "slug-zip": true
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,17 +2,3 @@ language: node_js
 node_js:
 - '0.12'
 sudo: false
-before_install:
-- pip install --user awscli && export PATH=$PATH:~/.local/bin/
-script:
-- ./bin/build
-- aws s3 cp --acl=public-read build/streambot.zip s3://mapbox/apps/streambot/${TRAVIS_COMMIT}.zip
-- if git describe --tags --exact-match 2> /dev/null; then aws s3 cp --acl=public-read build/streambot.zip s3://mapbox/apps/streambot/$(git describe --tags --exact-match).zip; fi
-- ./bin/bundle ./streambot-example
-- aws s3 cp --acl=public-read streambot-example/build/bundle.zip s3://mapbox/apps/streambot/${TRAVIS_COMMIT}-example.zip
-- if git describe --tags --exact-match 2> /dev/null; then aws s3 cp --acl=public-read streambot-example/build/bundle.zip s3://mapbox/apps/streambot/$(git describe --tags --exact-match)-example.zip; fi
-- npm test
-env:
-  global:
-  - secure: TZpt40WI5Y24ZoBb85x52GBLh719YXUTTQ9tfBLcKrPlh8QXPGUuwPVBOyTX0XOi5fWtADpAZ59zgDlrLiu1Eus39nidbxano9NdzUaYjvV+8PqfVqNgNjpQZXTIKfFERQVE3ILFR82TaSlsFE8GOleZdVafXzl1eFzinQZNiO0=
-  - secure: WoGKafmLKLpta+v04w8HxN2UApGzbMaLRrLny4O4q73H77f81PztUSEdyYOtXJCf2XnuNFVkGdthJpVPeZRH3+U80PmhHlUKs/LFJQImgZKC3EF6NvmWrxLpYNoisgoJTujeCXpbjMRwc2NYtn4npMI3bAGf2mJm3UkTaJzEVhM=

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,29 @@ language: node_js
 node_js:
 - '0.12'
 sudo: false
+before_install:
+- pip install --user awscli && export PATH=$PATH:~/.local/bin/
+script:
+- ./bin/build
+- aws s3 cp --acl=public-read build/streambot.zip s3://mapbox-us-east-1/release/streambot/${TRAVIS_COMMIT}.zip
+- aws s3 cp --acl=public-read build/streambot.zip s3://mapbox-us-west-2/release/streambot/${TRAVIS_COMMIT}.zip
+- aws s3 cp --acl=public-read build/streambot.zip s3://mapbox-eu-west-1/release/streambot/${TRAVIS_COMMIT}.zip
+- aws s3 cp --acl=public-read build/streambot.zip s3://mapbox-ap-northeast-1/release/streambot/${TRAVIS_COMMIT}.zip
+- if git describe --tags --exact-match 2> /dev/null; then aws s3 cp --acl=public-read build/streambot.zip s3://mapbox-us-east-1/release/streambot/$(git describe --tags --exact-match).zip; fi
+- if git describe --tags --exact-match 2> /dev/null; then aws s3 cp --acl=public-read build/streambot.zip s3://mapbox-us-west-2/release/streambot/$(git describe --tags --exact-match).zip; fi
+- if git describe --tags --exact-match 2> /dev/null; then aws s3 cp --acl=public-read build/streambot.zip s3://mapbox-eu-west-1/release/streambot/$(git describe --tags --exact-match).zip; fi
+- if git describe --tags --exact-match 2> /dev/null; then aws s3 cp --acl=public-read build/streambot.zip s3://mapbox-ap-northeast-1/release/streambot/$(git describe --tags --exact-match).zip; fi
+- ./bin/bundle ./streambot-example
+- aws s3 cp --acl=public-read streambot-example/build/bundle.zip s3://mapbox-us-east-1/release/streambot/${TRAVIS_COMMIT}-example.zip
+- aws s3 cp --acl=public-read streambot-example/build/bundle.zip s3://mapbox-us-west-2/release/streambot/${TRAVIS_COMMIT}-example.zip
+- aws s3 cp --acl=public-read streambot-example/build/bundle.zip s3://mapbox-eu-west-1/release/streambot/${TRAVIS_COMMIT}-example.zip
+- aws s3 cp --acl=public-read streambot-example/build/bundle.zip s3://mapbox-ap-northeast-1/release/streambot/${TRAVIS_COMMIT}-example.zip
+- if git describe --tags --exact-match 2> /dev/null; then aws s3 cp --acl=public-read streambot-example/build/bundle.zip s3://mapbox-us-east-1/release/streambot/$(git describe --tags --exact-match)-example.zip; fi
+- if git describe --tags --exact-match 2> /dev/null; then aws s3 cp --acl=public-read streambot-example/build/bundle.zip s3://mapbox-us-west-2/release/streambot/$(git describe --tags --exact-match)-example.zip; fi
+- if git describe --tags --exact-match 2> /dev/null; then aws s3 cp --acl=public-read streambot-example/build/bundle.zip s3://mapbox-eu-west-1/release/streambot/$(git describe --tags --exact-match)-example.zip; fi
+- if git describe --tags --exact-match 2> /dev/null; then aws s3 cp --acl=public-read streambot-example/build/bundle.zip s3://mapbox-ap-northeast-1/release/streambot/$(git describe --tags --exact-match)-example.zip; fi
+- npm test
+env:
+  global:
+  - secure: TZpt40WI5Y24ZoBb85x52GBLh719YXUTTQ9tfBLcKrPlh8QXPGUuwPVBOyTX0XOi5fWtADpAZ59zgDlrLiu1Eus39nidbxano9NdzUaYjvV+8PqfVqNgNjpQZXTIKfFERQVE3ILFR82TaSlsFE8GOleZdVafXzl1eFzinQZNiO0=
+  - secure: WoGKafmLKLpta+v04w8HxN2UApGzbMaLRrLny4O4q73H77f81PztUSEdyYOtXJCf2XnuNFVkGdthJpVPeZRH3+U80PmhHlUKs/LFJQImgZKC3EF6NvmWrxLpYNoisgoJTujeCXpbjMRwc2NYtn4npMI3bAGf2mJm3UkTaJzEVhM=

--- a/cloudformation/streambot.template.js
+++ b/cloudformation/streambot.template.js
@@ -174,7 +174,7 @@ module.exports = {
                         "Fn::Join": [
                             "",
                             [
-                                "slugs/streambot/",
+                                "release/streambot/",
                                 {
                                     "Ref": "GitSha"
                                 },
@@ -287,7 +287,7 @@ module.exports = {
                         "Fn::Join": [
                             "",
                             [
-                                "slugs/streambot/",
+                                "release/streambot/",
                                 {
                                     "Ref": "GitSha"
                                 },

--- a/cloudformation/travis.template
+++ b/cloudformation/travis.template
@@ -13,7 +13,10 @@
               "Statement": [
                 {
                   "Resource": [
-                    "arn:aws:s3:::mapbox/apps/streambot/*"
+                    "arn:aws:s3:::mapbox-us-east-1/release/streambot/*",
+                    "arn:aws:s3:::mapbox-us-west-2/release/streambot/*",
+                    "arn:aws:s3:::mapbox-eu-west-1/release/streambot/*",
+                    "arn:aws:s3:::mapbox-ap-northeast-1/release/streambot/*"
                   ],
                   "Action": [
                     "s3:PutObject",

--- a/docs/streambot.template.html
+++ b/docs/streambot.template.html
@@ -88,17 +88,10 @@ well-known location.</p>
                 <a class="pilcrow" href="#section-3">&#182;</a>
               </div>
               <h2 id="parameters">Parameters</h2>
-<p>Providing the Git SHA or version number of Streambot here insures that
-your Lambda functions are created using the expected version of Streambot.</p>
 
             </div>
             
-            <div class="content"><div class='highlight'><pre>    <span class="hljs-string">"Parameters"</span>: {
-        <span class="hljs-string">"GitSha"</span>: {
-            <span class="hljs-string">"Type"</span>: <span class="hljs-string">"String"</span>,
-            <span class="hljs-string">"Description"</span>: <span class="hljs-string">"The GitSha of Streambot to deploy"</span>
-        }
-    },</pre></div></div>
+            <div class="content"><div class='highlight'><pre>    <span class="hljs-string">"Parameters"</span>: {</pre></div></div>
             
         </li>
         
@@ -108,6 +101,84 @@ your Lambda functions are created using the expected version of Streambot.</p>
               
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-4">&#182;</a>
+              </div>
+              <p>Providing the Git SHA or version number of Streambot here insures that
+your Lambda functions are created using the expected version of Streambot.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>        <span class="hljs-string">"GitSha"</span>: {
+            <span class="hljs-string">"Type"</span>: <span class="hljs-string">"String"</span>,
+            <span class="hljs-string">"Description"</span>: <span class="hljs-string">"The GitSha of Streambot to deploy"</span>
+        },</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-5">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-5">&#182;</a>
+              </div>
+              <p>Provide the ARN of an existing streambot table in us-east-1 if running
+Streambot in another region</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>        <span class="hljs-string">"ExistingStreambotTable"</span>: {
+            <span class="hljs-string">"Type"</span>: <span class="hljs-string">"String"</span>,
+            <span class="hljs-string">"Description"</span>: <span class="hljs-string">"The ARN of an existing"</span>,
+            <span class="hljs-string">"Default"</span>: <span class="hljs-string">""</span>
+        }
+    },</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-6">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-6">&#182;</a>
+              </div>
+              <h2 id="conditions">Conditions</h2>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>    <span class="hljs-string">"Conditions"</span>: {</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-7">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-7">&#182;</a>
+              </div>
+              <p>Determines whether or not a table should be created</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>        <span class="hljs-string">"MakeTable"</span>: {
+            <span class="hljs-string">"Fn::Equals"</span>: [
+                {
+                    <span class="hljs-string">"Ref"</span>: <span class="hljs-string">"ExistingStreambotTable"</span>
+                },
+                <span class="hljs-string">""</span>
+            ]
+        }
+    },</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-8">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-8">&#182;</a>
               </div>
               <h2 id="resources">Resources</h2>
 <p>The stack creates two Lambda functions, and two IAM roles for those
@@ -120,11 +191,11 @@ Lambda functions to assume, and one DynamoDB table.</p>
         </li>
         
         
-        <li id="section-5">
+        <li id="section-9">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-5">&#182;</a>
+                <a class="pilcrow" href="#section-9">&#182;</a>
               </div>
               <h3 id="configuration-table">Configuration table</h3>
 <p>This DynamoDB table contains runtime configuration settings for your
@@ -134,16 +205,17 @@ Lambda functions.</p>
             
             <div class="content"><div class='highlight'><pre>        <span class="hljs-string">"StreambotEnvTable"</span>: {
             <span class="hljs-string">"Type"</span>: <span class="hljs-string">"AWS::DynamoDB::Table"</span>,
+            <span class="hljs-string">"Condition"</span>: <span class="hljs-string">"MakeTable"</span>,
             <span class="hljs-string">"Properties"</span>: {</pre></div></div>
             
         </li>
         
         
-        <li id="section-6">
+        <li id="section-10">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-6">&#182;</a>
+                <a class="pilcrow" href="#section-10">&#182;</a>
               </div>
               <p>It is important that this table name be hard-wired. Otherwise
 Lambda functions will not know where to look for
@@ -174,11 +246,11 @@ their configuration.</p>
         </li>
         
         
-        <li id="section-7">
+        <li id="section-11">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-7">&#182;</a>
+                <a class="pilcrow" href="#section-11">&#182;</a>
               </div>
               <h3 id="environment-configuration-role">Environment configuration role</h3>
 <p>This role is assumed by the StreambotEnv function</p>
@@ -192,11 +264,11 @@ their configuration.</p>
         </li>
         
         
-        <li id="section-8">
+        <li id="section-12">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-8">&#182;</a>
+                <a class="pilcrow" href="#section-12">&#182;</a>
               </div>
               <h4 id="assume-role-policy">Assume role policy</h4>
 <p>Identifies that this role can be assumed by a Lambda function.</p>
@@ -222,11 +294,11 @@ their configuration.</p>
         </li>
         
         
-        <li id="section-9">
+        <li id="section-13">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-9">&#182;</a>
+                <a class="pilcrow" href="#section-13">&#182;</a>
               </div>
               <h4 id="runtime-policy">Runtime policy</h4>
 <p>Defines the permissions that the Lambda function will
@@ -241,11 +313,11 @@ have once it has assumed this role.</p>
         </li>
         
         
-        <li id="section-10">
+        <li id="section-14">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-10">&#182;</a>
+                <a class="pilcrow" href="#section-14">&#182;</a>
               </div>
               <ul>
 <li>The Lambda function must be able to write
@@ -265,11 +337,11 @@ CloudWatch logs.</li>
         </li>
         
         
-        <li id="section-11">
+        <li id="section-15">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-11">&#182;</a>
+                <a class="pilcrow" href="#section-15">&#182;</a>
               </div>
               <ul>
 <li>The Lambda function must be able to write
@@ -285,18 +357,26 @@ configuration files to the DynamoDB table.</li>
                                         <span class="hljs-string">"dynamodb:DeleteItem"</span>
                                     ],
                                     <span class="hljs-string">"Resource"</span>: {
-                                        <span class="hljs-string">"Fn::Join"</span>: [
-                                            <span class="hljs-string">""</span>, [
-                                                <span class="hljs-string">"arn:aws:dynamodb:us-east-1:"</span>,
-                                                {
-                                                    <span class="hljs-string">"Ref"</span>: <span class="hljs-string">"AWS::AccountId"</span>
-                                                },
-                                                <span class="hljs-string">":table/"</span>,
-                                                {
-                                                    <span class="hljs-string">"Ref"</span>: <span class="hljs-string">"StreambotEnvTable"</span>
-                                                },
-                                                <span class="hljs-string">"*"</span>
-                                            ]
+                                        <span class="hljs-string">"Fn::If"</span>: [
+                                            <span class="hljs-string">"MakeTable"</span>,
+                                            {
+                                                <span class="hljs-string">"Fn::Join"</span>: [
+                                                    <span class="hljs-string">""</span>, [
+                                                        <span class="hljs-string">"arn:aws:dynamodb:us-east-1:"</span>,
+                                                        {
+                                                            <span class="hljs-string">"Ref"</span>: <span class="hljs-string">"AWS::AccountId"</span>
+                                                        },
+                                                        <span class="hljs-string">":table/"</span>,
+                                                        {
+                                                            <span class="hljs-string">"Ref"</span>: <span class="hljs-string">"StreambotEnvTable"</span>
+                                                        },
+                                                        <span class="hljs-string">"*"</span>
+                                                    ]
+                                                ]
+                                            },
+                                            {
+                                                <span class="hljs-string">"Ref"</span>: <span class="hljs-string">"ExistingStreambotTable"</span>
+                                            }
                                         ]
                                     }
                                 }
@@ -310,11 +390,11 @@ configuration files to the DynamoDB table.</li>
         </li>
         
         
-        <li id="section-12">
+        <li id="section-16">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-12">&#182;</a>
+                <a class="pilcrow" href="#section-16">&#182;</a>
               </div>
               <h3 id="streambotenv">StreambotEnv</h3>
 <p>This function is intended to be run by a custom CloudFormation
@@ -329,11 +409,11 @@ resource, and it is used to write a configuration file to S3.</p>
         </li>
         
         
-        <li id="section-13">
+        <li id="section-17">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-13">&#182;</a>
+                <a class="pilcrow" href="#section-17">&#182;</a>
               </div>
               <ul>
 <li>Code: The location of Streambot’s code for the desired
@@ -346,12 +426,22 @@ Streambot’s <code>index.js</code> file.</li>
             </div>
             
             <div class="content"><div class='highlight'><pre>                <span class="hljs-string">"Code"</span> : {
-                    <span class="hljs-string">"S3Bucket"</span>: <span class="hljs-string">"mapbox"</span>,
+                    <span class="hljs-string">"S3Bucket"</span>: {
+                        <span class="hljs-string">"Fn::Join"</span>: [
+                            <span class="hljs-string">"-"</span>,
+                            [
+                                <span class="hljs-string">"mapbox"</span>,
+                                {
+                                    <span class="hljs-string">"Ref"</span>: <span class="hljs-string">"AWS::Region"</span>
+                                }
+                            ]
+                        ]
+                    },
                     <span class="hljs-string">"S3Key"</span>: {
                         <span class="hljs-string">"Fn::Join"</span>: [
                             <span class="hljs-string">""</span>,
                             [
-                                <span class="hljs-string">"apps/streambot/"</span>,
+                                <span class="hljs-string">"slugs/streambot/"</span>,
                                 {
                                     <span class="hljs-string">"Ref"</span>: <span class="hljs-string">"GitSha"</span>
                                 },
@@ -364,11 +454,11 @@ Streambot’s <code>index.js</code> file.</li>
         </li>
         
         
-        <li id="section-14">
+        <li id="section-18">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-14">&#182;</a>
+                <a class="pilcrow" href="#section-18">&#182;</a>
               </div>
               <ul>
 <li>Handler: Identifies which function from Streambot’s
@@ -383,11 +473,11 @@ always be set to <code>index.env</code>.</li>
         </li>
         
         
-        <li id="section-15">
+        <li id="section-19">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-15">&#182;</a>
+                <a class="pilcrow" href="#section-19">&#182;</a>
               </div>
               <ul>
 <li>Role: A reference to the IAM role defined above that allows
@@ -406,11 +496,11 @@ this Lambda function to write files to DynamoDB.</li>
         </li>
         
         
-        <li id="section-16">
+        <li id="section-20">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-16">&#182;</a>
+                <a class="pilcrow" href="#section-20">&#182;</a>
               </div>
               <ul>
 <li>Other properties as outlined in the
@@ -429,11 +519,11 @@ this Lambda function to write files to DynamoDB.</li>
         </li>
         
         
-        <li id="section-17">
+        <li id="section-21">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-17">&#182;</a>
+                <a class="pilcrow" href="#section-21">&#182;</a>
               </div>
               <h3 id="environment-configuration-role">Environment configuration role</h3>
 <p>This role is assumed by the StreambotConnector function</p>
@@ -448,11 +538,11 @@ this Lambda function to write files to DynamoDB.</li>
         </li>
         
         
-        <li id="section-18">
+        <li id="section-22">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-18">&#182;</a>
+                <a class="pilcrow" href="#section-22">&#182;</a>
               </div>
               <h4 id="assume-role-policy">Assume role policy</h4>
 <p>Identifies that this role can be assumed by a Lambda function.</p>
@@ -477,11 +567,11 @@ this Lambda function to write files to DynamoDB.</li>
         </li>
         
         
-        <li id="section-19">
+        <li id="section-23">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-19">&#182;</a>
+                <a class="pilcrow" href="#section-23">&#182;</a>
               </div>
               <h4 id="runtime-policy">Runtime policy</h4>
 <p>Defines the permissions that the Lambda function will
@@ -496,11 +586,11 @@ have once it has assumed this role.</p>
         </li>
         
         
-        <li id="section-20">
+        <li id="section-24">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-20">&#182;</a>
+                <a class="pilcrow" href="#section-24">&#182;</a>
               </div>
               <ul>
 <li>The Lambda function must be able to write
@@ -520,11 +610,11 @@ CloudWatch logs.</li>
         </li>
         
         
-        <li id="section-21">
+        <li id="section-25">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-21">&#182;</a>
+                <a class="pilcrow" href="#section-25">&#182;</a>
               </div>
               <ul>
 <li>The Lambda function must be allowed to
@@ -554,11 +644,11 @@ manage event source mappings.</li>
         </li>
         
         
-        <li id="section-22">
+        <li id="section-26">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-22">&#182;</a>
+                <a class="pilcrow" href="#section-26">&#182;</a>
               </div>
               <h3 id="streambotconnector">StreambotConnector</h3>
 <p>This function is intended to be run by a custom CloudFormation
@@ -574,11 +664,11 @@ Kinesis/DynamoDB streams and Lambda functions.</p>
         </li>
         
         
-        <li id="section-23">
+        <li id="section-27">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-23">&#182;</a>
+                <a class="pilcrow" href="#section-27">&#182;</a>
               </div>
               <ul>
 <li>Code: The location of Streambot’s code for the desired
@@ -591,12 +681,22 @@ Streambot’s <code>index.js</code> file.</li>
             </div>
             
             <div class="content"><div class='highlight'><pre>                <span class="hljs-string">"Code"</span> : {
-                    <span class="hljs-string">"S3Bucket"</span>: <span class="hljs-string">"mapbox"</span>,
+                    <span class="hljs-string">"S3Bucket"</span>: {
+                        <span class="hljs-string">"Fn::Join"</span>: [
+                            <span class="hljs-string">"-"</span>,
+                            [
+                                <span class="hljs-string">"mapbox"</span>,
+                                {
+                                    <span class="hljs-string">"Ref"</span>: <span class="hljs-string">"AWS::Region"</span>
+                                }
+                            ]
+                        ]
+                    },
                     <span class="hljs-string">"S3Key"</span>: {
                         <span class="hljs-string">"Fn::Join"</span>: [
                             <span class="hljs-string">""</span>,
                             [
-                                <span class="hljs-string">"apps/streambot/"</span>,
+                                <span class="hljs-string">"slugs/streambot/"</span>,
                                 {
                                     <span class="hljs-string">"Ref"</span>: <span class="hljs-string">"GitSha"</span>
                                 },
@@ -609,11 +709,11 @@ Streambot’s <code>index.js</code> file.</li>
         </li>
         
         
-        <li id="section-24">
+        <li id="section-28">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-24">&#182;</a>
+                <a class="pilcrow" href="#section-28">&#182;</a>
               </div>
               <ul>
 <li>Handler: Identifies which function from Streambot’s
@@ -627,11 +727,11 @@ Streambot’s <code>index.js</code> file.</li>
         </li>
         
         
-        <li id="section-25">
+        <li id="section-29">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-25">&#182;</a>
+                <a class="pilcrow" href="#section-29">&#182;</a>
               </div>
               <ul>
 <li>Role: A reference to the IAM role defined above that allows
@@ -650,11 +750,11 @@ this Lambda function to write files to S3.</li>
         </li>
         
         
-        <li id="section-26">
+        <li id="section-30">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-26">&#182;</a>
+                <a class="pilcrow" href="#section-30">&#182;</a>
               </div>
               <ul>
 <li>Other properties as outlined in the
@@ -674,11 +774,11 @@ this Lambda function to write files to S3.</li>
         </li>
         
         
-        <li id="section-27">
+        <li id="section-31">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-27">&#182;</a>
+                <a class="pilcrow" href="#section-31">&#182;</a>
               </div>
               <h2 id="outputs">Outputs</h2>
 <p>For convenience, the Streambot stack provides outputs for values you will
@@ -691,11 +791,11 @@ need in order to implement Lambda-backed services.</p>
         </li>
         
         
-        <li id="section-28">
+        <li id="section-32">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-28">&#182;</a>
+                <a class="pilcrow" href="#section-32">&#182;</a>
               </div>
               <h3 id="streambotenv">StreambotEnv</h3>
 <p>This will be referenced by custom CloudFormation resources in your
@@ -715,11 +815,11 @@ service templates.</p>
         </li>
         
         
-        <li id="section-29">
+        <li id="section-33">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-29">&#182;</a>
+                <a class="pilcrow" href="#section-33">&#182;</a>
               </div>
               <ul>
 <li>The ARN of the StreambotEnv function</li>
@@ -739,11 +839,11 @@ service templates.</p>
         </li>
         
         
-        <li id="section-30">
+        <li id="section-34">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-30">&#182;</a>
+                <a class="pilcrow" href="#section-34">&#182;</a>
               </div>
               <h3 id="streambotconnector">StreambotConnector</h3>
 <p>This will be referenced by custom CloudFormation resources in your
@@ -763,11 +863,11 @@ service templates.</p>
         </li>
         
         
-        <li id="section-31">
+        <li id="section-35">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-31">&#182;</a>
+                <a class="pilcrow" href="#section-35">&#182;</a>
               </div>
               <ul>
 <li>The ARN of the StreambotConnector function</li>
@@ -780,44 +880,6 @@ service templates.</p>
                 <span class="hljs-string">"Fn::GetAtt"</span>: [
                     <span class="hljs-string">"StreambotConnectorFunction"</span>,
                     <span class="hljs-string">"Arn"</span>
-                ]
-            }
-        },</pre></div></div>
-            
-        </li>
-        
-        
-        <li id="section-32">
-            <div class="annotation">
-              
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-32">&#182;</a>
-              </div>
-              <h3 id="streambotenv-table">StreambotEnv Table</h3>
-<p>This is nice to know, but should not be required by your Lambda
-functions.</p>
-
-            </div>
-            
-            <div class="content"><div class='highlight'><pre>        <span class="hljs-string">"StreambotEnvTableName"</span>: {
-            <span class="hljs-string">"Value"</span>: {
-                <span class="hljs-string">"Ref"</span>: <span class="hljs-string">"StreambotEnvTable"</span>
-            }
-        },
-        <span class="hljs-string">"StreambotEnvTableArn"</span>: {
-            <span class="hljs-string">"Value"</span>: {
-                <span class="hljs-string">"Fn::Join"</span>: [
-                    <span class="hljs-string">""</span>, [
-                        <span class="hljs-string">"arn:aws:dynamodb:us-east-1:"</span>,
-                        {
-                            <span class="hljs-string">"Ref"</span>: <span class="hljs-string">"AWS::AccountId"</span>
-                        },
-                        <span class="hljs-string">":table/"</span>,
-                        {
-                            <span class="hljs-string">"Ref"</span>: <span class="hljs-string">"StreambotEnvTable"</span>
-                        },
-                        <span class="hljs-string">"*"</span>
-                    ]
                 ]
             }
         }


### PR DESCRIPTION
Enables streambot lambda functions to run in multiple regions, yet continue to reference a cannonical environment config table in us-east-1.